### PR TITLE
gi/oz3.0-update change openzeppelin version

### DIFF
--- a/contract/contracts/East.sol
+++ b/contract/contracts/East.sol
@@ -1,13 +1,10 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 
 import "../node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "../node_modules/@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
 
-contract East is ERC20, ERC20Detailed {
-  uint public INITIAL_SUPPLY = 1000000;
-
-  constructor(string memory _name, string memory _symbol)
-    ERC20Detailed(_name, _symbol, 0) public {
-    _mint(msg.sender, INITIAL_SUPPLY);
+contract East is ERC20 {
+  constructor(string memory _name, string memory _symbol, uint _initialSupply)
+    ERC20(_name, _symbol) public {
+    _mint(msg.sender, _initialSupply);
   }
 }

--- a/contract/contracts/Migrations.sol
+++ b/contract/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.21 <0.6.0;
+pragma solidity ^0.6.0;
 
 contract Migrations {
   address public owner;

--- a/contract/contracts/Public.sol
+++ b/contract/contracts/Public.sol
@@ -1,12 +1,10 @@
 pragma solidity ^0.6.0;
 
-import "../node_modules/openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "../node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract Public is ERC20 {
-  uint public INITIAL_SUPPLY = 1000000;
-
-  constructor(string memory _name, string memory _symbol)
+  constructor(string memory _name, string memory _symbol, uint _initialSupply)
     ERC20(_name, _symbol) public {
-    _mint(msg.sender, INITIAL_SUPPLY);
+    _mint(msg.sender, _initialSupply);
   }
 }

--- a/contract/migrations/2_deploy_contracts.js
+++ b/contract/migrations/2_deploy_contracts.js
@@ -2,7 +2,8 @@ var Public = artifacts.require("Public");
 
 const name = "EthiquePublic";
 const symbol = "EQP";
+let initialSupply = 1000000
 
 module.exports = function(deployer) {
-  deployer.deploy(Public, name, symbol);
+  deployer.deploy(Public, name, symbol, initialSupply);
 };

--- a/contract/package-lock.json
+++ b/contract/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@openzeppelin/contracts": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.0.tgz",
-      "integrity": "sha512-t3jm8FrhL9tkkJTofkznTqo/XXdHi21w5yXwalEnaMOp22ZwZ0f/mmKdlgMMLPFa6bSVHbY88mKESwJT/7m5Lg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.0.1.tgz",
+      "integrity": "sha512-uSrD7hZ0ViuHGqHZbeHawZBi/uy7aBiNramXAt2dFFuSuoU4u9insS3V3zdVfOnYSPreUo636xSOuQIFN4//HA=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -2732,7 +2732,7 @@
       "requires": {
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.1",
-        "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
+        "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
       },
       "dependencies": {
         "websocket": {

--- a/contract/package.json
+++ b/contract/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@openzeppelin/contracts": "^2.5.0"
+    "@openzeppelin/contracts": "^3.0.1"
   },
   "devDependencies": {
     "truffle-hdwallet-provider": "^1.0.17"

--- a/contract/private_contracts/3_deploy_private.js
+++ b/contract/private_contracts/3_deploy_private.js
@@ -1,9 +1,9 @@
-var Public = artifacts.require("Public");
 var East = artifacts.require("East");
 
 const name = "EthiqueEast";
 const symbol = "EQE";
+let initialSupply = 1000000
 
 module.exports = function(deployer) {
-  deployer.deploy(East, name, symbol);
+  deployer.deploy(East, name, symbol, initialSupply);
 };

--- a/contract/truffle-config.js
+++ b/contract/truffle-config.js
@@ -122,7 +122,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.5.0",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.6.2",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
Finish BC Openzeppelin change. OpenZeppelin version 3 uses solc 0.6.0 
and eliminated ERC20-Detailed.sol 